### PR TITLE
Add Parallel Search MCP preset

### DIFF
--- a/public/presetMcp.json
+++ b/public/presetMcp.json
@@ -360,5 +360,18 @@
         }
       }
     }
+  },
+  {
+    "name": "parallel-search",
+    "description": "Free web search and page retrieval; user-provided search objectives, search queries, and requested URLs are sent to Parallel",
+    "website": "https://docs.parallel.ai/integrations/mcp/search-mcp",
+    "config": {
+      "mcpServers": {
+        "parallel-search": {
+          "type": "streamable_http",
+          "url": "https://search.parallel.ai/mcp"
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- add Parallel Search as an optional curated MCP preset
- link to the official Search MCP integration documentation
- configure the hosted endpoint with the explicit `streamable_http` transport

Users must explicitly select the preset through the existing preset flow before it can be installed; this does not change defaults, connect automatically, add dependencies, or add authentication configuration.

For privacy clarity, user-provided search objectives, search queries, and requested URLs are sent to Parallel when the integration is used.

## Validation

- parsed `public/presetMcp.json` and verified all 21 existing entries remain unchanged and in the same order
- verified the appended preset's exact official website, transport type, endpoint, and privacy wording
- ran `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.